### PR TITLE
Add tests for code using ESM modules

### DIFF
--- a/tests/parser-types.test.js
+++ b/tests/parser-types.test.js
@@ -44,3 +44,41 @@ test("ESM with javascript/auto works", async () => {
     en: "Europe"
   });
 });
+
+test("with ESM in entry point works", async () => {
+  const pluginConfig = {
+    fullTranslations: {
+      en: { europe: "Europe" },
+      fi: { europe: "Eurooppa" }
+    },
+    functionNames: ["I18n.t"],
+    translationPlaceholderConstantName: "I18N_RUNTIME_TRANSLATIONS"
+  };
+
+  await compile({
+    plugin: new I18nRuntimePlugin(pluginConfig),
+
+    modules: {
+      "nonStrictEsm.js": `
+        export const en = I18n.t("europe", { locale: "en" });
+        export const fi = I18n.t("europe", { locale: "fi" });
+      `
+    },
+
+    entryCode: `
+      import I18n from "i18n-js";
+      import * as data from './nonStrictEsm';
+
+      window.I18n = I18n;
+      I18n.locale = 'en';
+      I18n.translations = I18N_RUNTIME_TRANSLATIONS;
+
+      window.testData = { fi: data.fi, en: data.en };
+    `
+  });
+
+  expect(window.testData).toEqual({
+    fi: "Eurooppa",
+    en: "Europe"
+  });
+});

--- a/tests/parser-types.test.js
+++ b/tests/parser-types.test.js
@@ -1,0 +1,46 @@
+/* @flow */
+
+const { compile } = require("./utils");
+const I18nRuntimePlugin = require("../lib/index");
+
+afterEach(() => {
+  delete window.testData;
+});
+
+test("ESM with javascript/auto works", async () => {
+  const pluginConfig = {
+    fullTranslations: {
+      en: { europe: "Europe" },
+      fi: { europe: "Eurooppa" }
+    },
+    functionNames: ["I18n.t"],
+    translationPlaceholderConstantName: "I18N_RUNTIME_TRANSLATIONS"
+  };
+
+  await compile({
+    plugin: new I18nRuntimePlugin(pluginConfig),
+
+    modules: {
+      "nonStrictEsm.js": `
+        export const en = I18n.t("europe", { locale: "en" });
+        export const fi = I18n.t("europe", { locale: "fi" });
+      `
+    },
+
+    entryCode: `
+      const I18n = require("i18n-js");
+
+      window.I18n = I18n;
+      I18n.locale = 'en';
+      I18n.translations = I18N_RUNTIME_TRANSLATIONS;
+
+      const data = require('./nonStrictEsm');
+      window.testData = { fi: data.fi, en: data.en };
+    `
+  });
+
+  expect(window.testData).toEqual({
+    fi: "Eurooppa",
+    en: "Europe"
+  });
+});


### PR DESCRIPTION
I wanted these tests to be based on top of current `master`, before https://github.com/venuu/i18n-js-webpack-plugin/pull/1 is merged, to show how the current code works with code containing `import` / `export` statements.

Also of note is that in here, we have a failing scenario for `.mjs` modules. I've yet still to figure out how to make it work.